### PR TITLE
test: missing case for parseRelFile

### DIFF
--- a/test/Main.hs
+++ b/test/Main.hs
@@ -46,7 +46,7 @@ restrictions =
              (isNothing (void (parseAbsDir x) <|>
                          void (parseRelDir x) <|>
                          void (parseAbsFile x) <|>
-                         void (parseRelDir x)))
+                         void (parseRelFile x)))
 
 -- | The 'filename' operation.
 operationFilename :: Spec


### PR DESCRIPTION
I think this was a typo.