### PR TITLE
Various improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ cabal-dev/
 TAGS
 tags
 *.tag
+.stack-work/

--- a/src/Path.hs
+++ b/src/Path.hs
@@ -81,7 +81,7 @@ parseAbsDir :: MonadThrow m
 parseAbsDir filepath =
   if FilePath.isAbsolute filepath &&
      not (null (normalizeDir filepath)) &&
-     not (isPrefixOf "~/" filepath) &&
+     not ("~/" `isPrefixOf` filepath) &&
      not (hasParentDir filepath)
      then return (Path (normalizeDir filepath))
      else throwM (InvalidAbsDir filepath)
@@ -96,7 +96,7 @@ parseRelDir :: MonadThrow m
 parseRelDir filepath =
   if not (FilePath.isAbsolute filepath) &&
      not (null filepath) &&
-     not (isPrefixOf "~/" filepath) &&
+     not ("~/" `isPrefixOf` filepath) &&
      not (hasParentDir filepath) &&
      not (null (normalizeDir filepath)) &&
      filepath /= ".."
@@ -112,7 +112,7 @@ parseAbsFile :: MonadThrow m
 parseAbsFile filepath =
   if FilePath.isAbsolute filepath &&
      not (FilePath.hasTrailingPathSeparator filepath) &&
-     not (isPrefixOf "~/" filepath) &&
+     not ("~/" `isPrefixOf` filepath) &&
      not (hasParentDir filepath) &&
      not (null (normalizeFile filepath)) &&
      filepath /= ".."
@@ -129,7 +129,7 @@ parseRelFile filepath =
   if not (FilePath.isAbsolute filepath ||
           FilePath.hasTrailingPathSeparator filepath) &&
      not (null filepath) &&
-     not (isPrefixOf "~/" filepath) &&
+     not ("~/" `isPrefixOf` filepath) &&
      not (hasParentDir filepath) &&
      not (null (normalizeFile filepath)) &&
      filepath /= ".."
@@ -140,9 +140,9 @@ parseRelFile filepath =
 -- This handles the logic of checking for different path separators on Windows.
 hasParentDir :: FilePath -> Bool
 hasParentDir filepath' =
-     (isSuffixOf "/.." filepath) ||
-     (isInfixOf "/../" filepath) ||
-     (isPrefixOf "../" filepath)
+     ("/.." `isSuffixOf` filepath) ||
+     ("/../" `isInfixOf` filepath) ||
+     ("../" `isPrefixOf` filepath)
   where
     filepath =
         case FilePath.pathSeparator of

--- a/src/Path.hs
+++ b/src/Path.hs
@@ -31,6 +31,10 @@ module Path
   ,dirname
   -- * Conversion
   ,toFilePath
+  ,fromAbsDir
+  ,fromRelDir
+  ,fromAbsFile
+  ,fromRelFile
   )
   where
 
@@ -202,6 +206,22 @@ mkRelFile s =
 -- the filepath package.
 toFilePath :: Path b t -> FilePath
 toFilePath (Path l) = l
+
+-- | Convert absolute path to directory to 'FilePath' type.
+fromAbsDir :: Path Abs Dir -> FilePath
+fromAbsDir = toFilePath
+
+-- | Convert relative path to directory to 'FilePath' type.
+fromRelDir :: Path Rel Dir -> FilePath
+fromRelDir = toFilePath
+
+-- | Convert absolute path to file to 'FilePath' type.
+fromAbsFile :: Path Abs File -> FilePath
+fromAbsFile = toFilePath
+
+-- | Convert relative path to file to 'FilePath' type.
+fromRelFile :: Path Rel File -> FilePath
+fromRelFile = toFilePath
 
 --------------------------------------------------------------------------------
 -- Operations

--- a/src/Path/Internal.hs
+++ b/src/Path/Internal.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 -- | Internal types and functions.
 


### PR DESCRIPTION
Thanks for this library, I use it everywhere now. Most of these edits are completely optional, but type-safe synonyms for `toFilePath` is something I *always* define, simply because I want type-checker “double-check” me when I leave domain of this library and convert things into `FilePath` (which is just a `String` after all). Rationale is: you always know what kind of path you want to convert to `FilePath`, but `toFilePath` will convert *anything* into `FilePath`, even if it happens to be of wrong type (you think about absolute path, but it's relative — not impossible situation unless you put type-signatures for all intermediate transformations), so I don't trust myself, I trust type-checker, hence these synonyms.

----

There are quite a few commits there, how about publishing new release of the library? Thanks for your work.
