### PR TITLE
Adding a few tests that fail but shouldn't.

### DIFF
--- a/test/Main.hs
+++ b/test/Main.hs
@@ -149,13 +149,18 @@ parseRelDirSpec =
      failing "//"
      failing "~/"
      failing "/"
-     failing "./"
      failing "//"
+     failing "./foo/../bar/"
+     failing "../foo/../bar/"
      failing "///foo//bar//mu/"
      failing "///foo//bar////mu"
      failing "///foo//bar/.//mu"
+     succeeding "./" (Path "./")
+     succeeding "../" (Path "../")
      succeeding "foo.bak" (Path "foo.bak/")
      succeeding "./foo" (Path "foo/")
+     succeeding "../foo" (Path "../foo/")
+     succeeding "./../foo" (Path "../foo/")
      succeeding "foo//bar//mu//" (Path "foo/bar/mu/")
      succeeding "foo//bar////mu" (Path "foo/bar/mu/")
      succeeding "foo//bar/.//mu" (Path "foo/bar/mu/")
@@ -187,12 +192,16 @@ parseRelFileSpec =
      failing "~/"
      failing "/"
      failing "./"
+     failing "../foo/../bar.txt"
+     failing "./../foo/../bar.txt"
      failing "//"
      failing "///foo//bar//mu/"
      failing "///foo//bar////mu"
      failing "///foo//bar/.//mu"
      succeeding "foo.txt" (Path "foo.txt")
      succeeding "./foo.txt" (Path "foo.txt")
+     succeeding "../foo.txt" (Path "../foo.txt")
+     succeeding "./../foo.txt" (Path "../foo.txt")
      succeeding "foo//bar//mu.txt" (Path "foo/bar/mu.txt")
      succeeding "foo//bar////mu.txt" (Path "foo/bar/mu.txt")
      succeeding "foo//bar/.//mu.txt" (Path "foo/bar/mu.txt")


### PR DESCRIPTION
These tests fail because the current implementation doesn't consider
paths containing `../` anywhere to be relative paths. I think that's
wrong, a relative path should be able to *start* with `../`.