### PR TITLE
Clarify what limitations the RelX parsers have.

### DIFF
--- a/src/Path.hs
+++ b/src/Path.hs
@@ -93,6 +93,8 @@ parseAbsDir filepath =
 -- | Get a location for a relative directory. Produces a normalized
 -- path which always ends in a path separator.
 --
+-- Note that @filepath@ may contain any number of @./@ but may not consist solely of @./@.  It also may not contain a single @..@ anywhere.
+--
 -- Throws: 'PathParseException'
 --
 parseRelDir :: MonadThrow m
@@ -124,6 +126,8 @@ parseAbsFile filepath =
      else throwM (InvalidAbsFile filepath)
 
 -- | Get a location for a relative file.
+--
+-- Note that @filepath@ may contain any number of @./@ but may not contain a single @..@ anywhere.
 --
 -- Throws: 'PathParseException'
 --

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -150,12 +150,15 @@ parseRelDirSpec =
      failing "~/"
      failing "/"
      failing "./"
+     failing "././"
      failing "//"
      failing "///foo//bar//mu/"
      failing "///foo//bar////mu"
      failing "///foo//bar/.//mu"
      succeeding "foo.bak" (Path "foo.bak/")
      succeeding "./foo" (Path "foo/")
+     succeeding "././foo" (Path "foo/")
+     succeeding "./foo/./bar" (Path "foo/bar/")
      succeeding "foo//bar//mu//" (Path "foo/bar/mu/")
      succeeding "foo//bar////mu" (Path "foo/bar/mu/")
      succeeding "foo//bar/.//mu" (Path "foo/bar/mu/")
@@ -193,6 +196,8 @@ parseRelFileSpec =
      failing "///foo//bar/.//mu"
      succeeding "foo.txt" (Path "foo.txt")
      succeeding "./foo.txt" (Path "foo.txt")
+     succeeding "././foo.txt" (Path "foo.txt")
+     succeeding "./foo/./bar.txt" (Path "foo/bar.txt")
      succeeding "foo//bar//mu.txt" (Path "foo/bar/mu.txt")
      succeeding "foo//bar////mu.txt" (Path "foo/bar/mu.txt")
      succeeding "foo//bar/.//mu.txt" (Path "foo/bar/mu.txt")


### PR DESCRIPTION
The behaviour is surprising given the rather established meaning of *relative path*.  Since `path` doesn't quite follow that meaning (and for good reasons) the next best thing is clarifying documentation.