### PR TITLE
Fix a haddock parse error

### DIFF
--- a/src/Path.hs
+++ b/src/Path.hs
@@ -13,8 +13,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE EmptyDataDecls #-}
 
--- | A normalizing well-typed path type.
-
 module Path
   (-- * Types
    Path


### PR DESCRIPTION
The line was triggering parse error when running haddock:

```
src/Path.hs:16:1:
    parse error on input ‘-- | A normalizing well-typed path type.’
```

Removing it works for me.