### PR TITLE
src/Path.hs: fixed haddock markup

### DIFF
--- a/src/Path.hs
+++ b/src/Path.hs
@@ -13,8 +13,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE EmptyDataDecls #-}
 
--- | A normalizing well-typed path type.
-
 module Path
   (-- * Types
    Path


### PR DESCRIPTION
haddock broke as:
  Running Haddock for path-0.5.6...
  Running hscolour for path-0.5.6...
  Preprocessing library path-0.5.6...
  Preprocessing test suite 'test' for path-0.5.6...
  Preprocessing library path-0.5.6...

  src/Path.hs:16:1:
     parse error on input ‘-- | A normalizing well-typed path type.’

Signed-off-by: Sergei Trofimovich <siarheit@google.com>