### PR TITLE
Add cabal Travis jobs to check compatibility with older ghcs and cutting edge packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,25 @@ cache:
 #     addons: {apt: {packages: [libfcgi-dev,libgmp-dev]}}
 matrix:
   include:
+  - env: BUILD=cabal GHCVER=7.0.4 CABALVER=1.16
+    compiler: ": #cabal 7.0.4"
+    addons: {apt: {packages: [cabal-install-1.16,ghc-7.0.4], sources: [hvr-ghc]}}
+
+  - env: BUILD=cabal GHCVER=7.2.2 CABALVER=1.16
+    compiler: ": #cabal 7.2.2"
+    addons: {apt: {packages: [cabal-install-1.16,ghc-7.2.2], sources: [hvr-ghc]}}
+
+  - env: BUILD=cabal GHCVER=7.4.2 CABALVER=1.16
+    compiler: ": #cabal 7.4.2"
+    addons: {apt: {packages: [cabal-install-1.16,ghc-7.4.2], sources: [hvr-ghc]}}
+
+  - env: BUILD=cabal GHCVER=7.6.3 CABALVER=1.16
+    compiler: ": #cabal 7.6.3"
+    addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3], sources: [hvr-ghc]}}
+
+  - env: BUILD=cabal GHCVER=8.0.1 CABALVER=1.24
+    compiler: ": #cabal 8.0.1"
+    addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1], sources: [hvr-ghc]}}
 
   - env: BUILD=stack ARGS="--resolver lts-2"
     compiler: ": #stack 7.8.4"

--- a/path.cabal
+++ b/path.cabal
@@ -18,7 +18,7 @@ library
   exposed-modules:   Path, Path.Internal
   build-depends:     base >= 4 && <5
                    , exceptions
-                   , filepath
+                   , filepath < 1.2.0.1 || >= 1.3
                    , template-haskell
                    , deepseq
                    , aeson

--- a/path.cabal
+++ b/path.cabal
@@ -30,6 +30,7 @@ test-suite test
     build-depends: HUnit
                  , aeson
                  , base
+                 , bytestring
                  , hspec
                  , mtl
                  , path

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -223,7 +223,7 @@ parserTest parser input expected =
       case expected of
         Nothing -> "should fail."
         Just x -> "should succeed with: " ++ show x)
-     (actual == expected)
+     (actual `shouldBe` expected)
   where actual = parser input
 
 -- | Tests for the 'ToJSON' and 'FromJSON' instances

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 -- | Test suite.
 
@@ -8,6 +7,7 @@ module Main where
 import Control.Applicative
 import Control.Monad
 import Data.Aeson
+import qualified Data.ByteString.Lazy.Char8 as LBS
 import Data.Maybe
 import Path
 import Path.Internal
@@ -227,11 +227,14 @@ parserTest parser input expected =
   where actual = parser input
 
 -- | Tests for the 'ToJSON' and 'FromJSON' instances
+--
+-- Can't use overloaded strings due to some weird issue with bytestring-0.9.2.1 / ghc-7.4.2:
+-- https://travis-ci.org/sjakobi/path/jobs/138399072#L989
 aesonInstances :: Spec
 aesonInstances =
   do it "Decoding \"[\"/foo/bar\"]\" as a [Path Abs Dir] should succeed." $
-       eitherDecode "[\"/foo/bar\"]" `shouldBe` Right [Path "/foo/bar/" :: Path Abs Dir]
+       eitherDecode (LBS.pack "[\"/foo/bar\"]") `shouldBe` Right [Path "/foo/bar/" :: Path Abs Dir]
      it "Decoding \"[\"/foo/bar\"]\" as a [Path Rel Dir] should fail." $
-       decode "[\"/foo/bar\"]" `shouldBe` (Nothing :: Maybe [Path Rel Dir])
+       decode (LBS.pack "[\"/foo/bar\"]") `shouldBe` (Nothing :: Maybe [Path Rel Dir])
      it "Encoding \"[\"/foo/bar/mu.txt\"]\" should succeed." $
-       encode [Path "/foo/bar/mu.txt" :: Path Abs File] `shouldBe` "[\"/foo/bar/mu.txt\"]"
+       encode [Path "/foo/bar/mu.txt" :: Path Abs File] `shouldBe` (LBS.pack "[\"/foo/bar/mu.txt\"]")


### PR DESCRIPTION
I ran into https://github.com/lpsmith/bytestring-builder/issues/8 on the way, which might be a recurring issue.