### PR TITLE
The first step towards validity-based testing.

### DIFF
--- a/path.cabal
+++ b/path.cabal
@@ -22,19 +22,24 @@ library
                    , template-haskell
                    , deepseq
                    , aeson
-                   , validity
 
 test-suite test
     type: exitcode-stdio-1.0
     main-is: Main.hs
+    other-modules: Path.Gen
     hs-source-dirs: test
     build-depends: HUnit
+                 , QuickCheck
                  , aeson
                  , base
                  , bytestring
+                 , filepath
+                 , genvalidity
+                 , genvalidity-hspec
                  , hspec
                  , mtl
                  , path
+                 , validity
 
 source-repository head
     type:     git

--- a/path.cabal
+++ b/path.cabal
@@ -22,6 +22,7 @@ library
                    , template-haskell
                    , deepseq
                    , aeson
+                   , validity
 
 test-suite test
     type: exitcode-stdio-1.0

--- a/src/Path.hs
+++ b/src/Path.hs
@@ -56,6 +56,7 @@ import qualified Data.Aeson.Types as Aeson
 import           Data.Data
 import           Data.List
 import           Data.Maybe
+import           Data.Validity
 import           Language.Haskell.TH
 import           Path.Internal
 import qualified System.FilePath as FilePath
@@ -77,6 +78,26 @@ data File deriving (Typeable)
 
 -- | A directory path.
 data Dir deriving (Typeable)
+
+instance Validity (Path Abs File) where
+  isValid (Path fp)
+    =  FilePath.isAbsolute fp
+    && not (FilePath.hasTrailingPathSeparator fp)
+
+instance Validity (Path Rel File) where
+  isValid (Path fp)
+    =  FilePath.isRelative fp
+    && not (FilePath.hasTrailingPathSeparator fp)
+
+instance Validity (Path Abs Dir) where
+  isValid (Path fp)
+    =  FilePath.isAbsolute fp
+    && FilePath.hasTrailingPathSeparator fp
+
+instance Validity (Path Rel Dir) where
+  isValid (Path fp)
+    =  FilePath.isRelative fp
+    && FilePath.hasTrailingPathSeparator fp
 
 instance FromJSON (Path Abs File) where
   parseJSON = parseJSONWith parseAbsFile

--- a/src/Path.hs
+++ b/src/Path.hs
@@ -56,7 +56,6 @@ import qualified Data.Aeson.Types as Aeson
 import           Data.Data
 import           Data.List
 import           Data.Maybe
-import           Data.Validity
 import           Language.Haskell.TH
 import           Path.Internal
 import qualified System.FilePath as FilePath
@@ -78,26 +77,6 @@ data File deriving (Typeable)
 
 -- | A directory path.
 data Dir deriving (Typeable)
-
-instance Validity (Path Abs File) where
-  isValid (Path fp)
-    =  FilePath.isAbsolute fp
-    && not (FilePath.hasTrailingPathSeparator fp)
-
-instance Validity (Path Rel File) where
-  isValid (Path fp)
-    =  FilePath.isRelative fp
-    && not (FilePath.hasTrailingPathSeparator fp)
-
-instance Validity (Path Abs Dir) where
-  isValid (Path fp)
-    =  FilePath.isAbsolute fp
-    && FilePath.hasTrailingPathSeparator fp
-
-instance Validity (Path Rel Dir) where
-  isValid (Path fp)
-    =  FilePath.isRelative fp
-    && FilePath.hasTrailingPathSeparator fp
 
 instance FromJSON (Path Abs File) where
   parseJSON = parseJSONWith parseAbsFile

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,5 @@
+flags: {}
+extra-deps:
+- path-0.5.9
+- validity-0.3.0.1
 resolver: lts-6.3

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,7 @@
 flags: {}
 extra-deps:
+- genvalidity-0.2.0.1
+- genvalidity-hspec-0.2.0.4
 - path-0.5.9
 - validity-0.3.0.1
 resolver: lts-6.3

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -12,6 +12,10 @@ import Data.Maybe
 import Path
 import Path.Internal
 import Test.Hspec
+import Test.Validity
+import Test.QuickCheck
+
+import Path.Gen ()
 
 -- | Test suite entry point, returns exit failure if any test fails.
 main :: IO ()
@@ -68,6 +72,12 @@ operationFilename =
                    filename $(mkRelFile "bar.txt")) ==
          $(mkRelFile "bar.txt"))
 
+     it "produces a valid path on when passed a valid absolute path" $ do
+        producesValidsOnValids (filename :: Path Abs File -> Path Rel File)
+
+     it "produces a valid path on when passed a valid relative path" $ do
+        producesValidsOnValids (filename :: Path Rel File -> Path Rel File)
+
 -- | The 'parent' operation.
 operationParent :: Spec
 operationParent =
@@ -81,6 +91,12 @@ operationParent =
      it "parent (parent \"\") == \"\""
         (parent (parent $(mkAbsDir "/")) ==
          $(mkAbsDir "/"))
+
+     it "produces a valid path on when passed a valid file path " $ do
+        producesValidsOnValids (parent :: Path Abs File -> Path Abs Dir)
+
+     it "produces a valid path on when passed a valid directory path" $ do
+        producesValidsOnValids (parent :: Path Abs Dir -> Path Abs Dir)
 
 -- | The 'isParentOf' operation.
 operationIsParentOf :: Spec
@@ -145,6 +161,10 @@ parseAbsDirSpec =
      succeeding "///foo//bar//mu/" (Path "/foo/bar/mu/")
      succeeding "///foo//bar////mu" (Path "/foo/bar/mu/")
      succeeding "///foo//bar/.//mu" (Path "/foo/bar/mu/")
+
+     it "Produces valid paths when it succeeds" $
+       validIfSucceedsOnArbitrary
+         (parseAbsDir :: FilePath -> Maybe (Path Abs Dir))
   where failing x = parserTest parseAbsDir x Nothing
         succeeding x with = parserTest parseAbsDir x (Just with)
 
@@ -170,6 +190,10 @@ parseRelDirSpec =
      succeeding "foo//bar//mu//" (Path "foo/bar/mu/")
      succeeding "foo//bar////mu" (Path "foo/bar/mu/")
      succeeding "foo//bar/.//mu" (Path "foo/bar/mu/")
+
+     it "Produces valid paths when it succeeds" $
+       validIfSucceedsOnArbitrary
+         (parseRelDir :: FilePath -> Maybe (Path Rel Dir))
   where failing x = parserTest parseRelDir x Nothing
         succeeding x with = parserTest parseRelDir x (Just with)
 
@@ -187,6 +211,10 @@ parseAbsFileSpec =
      succeeding "/foo.txt" (Path "/foo.txt")
      succeeding "///foo//bar////mu.txt" (Path "/foo/bar/mu.txt")
      succeeding "///foo//bar/.//mu.txt" (Path "/foo/bar/mu.txt")
+
+     it "Produces valid paths when it succeeds" $
+       validIfSucceedsOnArbitrary
+         (parseAbsFile :: FilePath -> Maybe (Path Abs File))
   where failing x = parserTest parseAbsFile x Nothing
         succeeding x with = parserTest parseAbsFile x (Just with)
 
@@ -211,6 +239,10 @@ parseRelFileSpec =
      succeeding "foo//bar//mu.txt" (Path "foo/bar/mu.txt")
      succeeding "foo//bar////mu.txt" (Path "foo/bar/mu.txt")
      succeeding "foo//bar/.//mu.txt" (Path "foo/bar/mu.txt")
+
+     it "Produces valid paths when it succeeds" $
+       validIfSucceedsOnArbitrary
+         (parseRelFile :: FilePath -> Maybe (Path Rel File))
   where failing x = parserTest parseRelFile x Nothing
         succeeding x with = parserTest parseRelFile x (Just with)
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -92,7 +92,7 @@ operationParent =
         (parent (parent $(mkAbsDir "/")) ==
          $(mkAbsDir "/"))
 
-     it "produces a valid path on when passed a valid file path " $ do
+     it "produces a valid path on when passed a valid file path" $ do
         producesValidsOnValids (parent :: Path Abs File -> Path Abs Dir)
 
      it "produces a valid path on when passed a valid directory path" $ do
@@ -130,6 +130,18 @@ operationStripDir =
                   $(mkAbsDir "/home/chris/foo") ==
          Nothing)
 
+     it "produces a valid path on when passed a valid absolute file paths" $ do
+        producesValidsOnValids2 (stripDir :: Path Abs Dir -> Path Abs File -> Maybe (Path Rel File))
+
+     it "produces a valid path on when passed a valid absolute directory paths" $ do
+        producesValidsOnValids2 (stripDir :: Path Abs Dir -> Path Abs Dir -> Maybe (Path Rel Dir))
+
+     it "produces a valid path on when passed a valid relative file paths" $ do
+        producesValidsOnValids2 (stripDir :: Path Rel Dir -> Path Rel File -> Maybe (Path Rel File))
+
+     it "produces a valid path on when passed a valid relative directory paths" $ do
+        producesValidsOnValids2 (stripDir :: Path Rel Dir -> Path Rel Dir -> Maybe (Path Rel Dir))
+
 -- | The '</>' operation.
 operationAppend :: Spec
 operationAppend =
@@ -149,6 +161,18 @@ operationAppend =
         ($(mkRelDir "home/") </>
          $(mkRelFile "chris/test.txt") ==
          $(mkRelFile "home/chris/test.txt"))
+
+     it "produces a valid path on when creating valid absolute file paths" $ do
+        producesValidsOnValids2 ((</>) :: Path Abs Dir -> Path Rel File -> Path Abs File)
+
+     it "produces a valid path on when creating valid absolute directory paths" $ do
+        producesValidsOnValids2 ((</>) :: Path Abs Dir -> Path Rel Dir -> Path Abs Dir)
+
+     it "produces a valid path on when creating valid relative file paths" $ do
+        producesValidsOnValids2 ((</>) :: Path Rel Dir -> Path Rel File -> Path Rel File)
+
+     it "produces a valid path on when creating valid relative directory paths" $ do
+        producesValidsOnValids2 ((</>) :: Path Rel Dir -> Path Rel Dir -> Path Rel Dir)
 
 -- | Tests for the tokenizer.
 parseAbsDirSpec :: Spec

--- a/test/Path/Gen.hs
+++ b/test/Path/Gen.hs
@@ -6,6 +6,7 @@ import           Path.Internal
 
 import qualified System.FilePath as FilePath
 
+import           Data.List (isInfixOf)
 import           Data.Validity
 import           Data.GenValidity
 
@@ -16,21 +17,35 @@ instance Validity (Path Abs File) where
   isValid (Path fp)
     =  FilePath.isAbsolute fp
     && not (FilePath.hasTrailingPathSeparator fp)
+    && FilePath.isValid fp
+    && not (".." `isInfixOf` fp)
 
 instance Validity (Path Rel File) where
   isValid (Path fp)
     =  FilePath.isRelative fp
     && not (FilePath.hasTrailingPathSeparator fp)
+    && FilePath.isValid fp
+    && fp /= "."
+    && fp /= ".."
+    && not (".." `isInfixOf` fp)
 
 instance Validity (Path Abs Dir) where
   isValid (Path fp)
     =  FilePath.isAbsolute fp
     && FilePath.hasTrailingPathSeparator fp
+    && FilePath.isValid fp
+    && not (".." `isInfixOf` fp)
 
 instance Validity (Path Rel Dir) where
   isValid (Path fp)
     =  FilePath.isRelative fp
     && FilePath.hasTrailingPathSeparator fp
+    && FilePath.isValid fp
+    && not (null fp)
+    && fp /= "."
+    && fp /= ".."
+    && not (".." `isInfixOf` fp)
+
 
 
 instance GenValidity (Path Abs File) where

--- a/test/Path/Gen.hs
+++ b/test/Path/Gen.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE FlexibleInstances #-}
+module Path.Gen where
+
+import           Path
+import           Path.Internal
+
+import qualified System.FilePath as FilePath
+
+import           Data.Validity
+import           Data.GenValidity
+
+import           Test.QuickCheck
+
+
+instance Validity (Path Abs File) where
+  isValid (Path fp)
+    =  FilePath.isAbsolute fp
+    && not (FilePath.hasTrailingPathSeparator fp)
+
+instance Validity (Path Rel File) where
+  isValid (Path fp)
+    =  FilePath.isRelative fp
+    && not (FilePath.hasTrailingPathSeparator fp)
+
+instance Validity (Path Abs Dir) where
+  isValid (Path fp)
+    =  FilePath.isAbsolute fp
+    && FilePath.hasTrailingPathSeparator fp
+
+instance Validity (Path Rel Dir) where
+  isValid (Path fp)
+    =  FilePath.isRelative fp
+    && FilePath.hasTrailingPathSeparator fp
+
+
+instance GenValidity (Path Abs File) where
+  genUnchecked = Path <$> arbitrary
+
+instance GenValidity (Path Rel File) where
+  genUnchecked = Path <$> arbitrary
+
+instance GenValidity (Path Abs Dir) where
+  genUnchecked = Path <$> arbitrary
+
+instance GenValidity (Path Rel Dir) where
+  genUnchecked = Path <$> arbitrary
+


### PR DESCRIPTION
This `path` library is very scarsely tested. I would like to improve that.
There are invariants for the `Path` type.
We should:

1. Make those invariants explicit
2. Make sure that all the functions that produce a `Path`, can only produce valid `Path`s.
3. Add a bunch of property tests.
4. Add doctests to show what functions should (intuitively) do
5. Add/Generate a bunch of unit tests to ensure that the API is invariant under refactors/optimisations
(6.) Optimise the internals to use something better than `String`.

This commit just takes the first step by adding a `Validity` instance for `Path`s.

I would like to hear your thoughts on the matter.
See https://github.com/NorfairKing/safepath for the level of testing I would like to achieve here.