### PR TITLE
Stricter validity instance that exposes some bugs

### DIFF
--- a/test/Path/Gen.hs
+++ b/test/Path/Gen.hs
@@ -14,30 +14,33 @@ import           Test.QuickCheck
 
 
 instance Validity (Path Abs File) where
-  isValid (Path fp)
+  isValid p@(Path fp)
     =  FilePath.isAbsolute fp
     && not (FilePath.hasTrailingPathSeparator fp)
     && FilePath.isValid fp
     && not (".." `isInfixOf` fp)
+    && (parseAbsFile fp == Just p)
 
 instance Validity (Path Rel File) where
-  isValid (Path fp)
+  isValid p@(Path fp)
     =  FilePath.isRelative fp
     && not (FilePath.hasTrailingPathSeparator fp)
     && FilePath.isValid fp
     && fp /= "."
     && fp /= ".."
     && not (".." `isInfixOf` fp)
+    && (parseRelFile fp == Just p)
 
 instance Validity (Path Abs Dir) where
-  isValid (Path fp)
+  isValid p@(Path fp)
     =  FilePath.isAbsolute fp
     && FilePath.hasTrailingPathSeparator fp
     && FilePath.isValid fp
     && not (".." `isInfixOf` fp)
+    && (parseAbsDir fp == Just p)
 
 instance Validity (Path Rel Dir) where
-  isValid (Path fp)
+  isValid p@(Path fp)
     =  FilePath.isRelative fp
     && FilePath.hasTrailingPathSeparator fp
     && FilePath.isValid fp
@@ -45,6 +48,7 @@ instance Validity (Path Rel Dir) where
     && fp /= "."
     && fp /= ".."
     && not (".." `isInfixOf` fp)
+    && (parseRelDir fp == Just p)
 
 
 


### PR DESCRIPTION
This was made as a reply to #37.

This PR makes the validity instances for typed path more strict and exposes some bugs in doing so:

```
$(mkAbsFile "/.") -- DANGEROUS
"/"
$(mkRelFile "a/.") -- Disobeys invariant: file does not end in slash
"a/"
$(mkRelFile "a..") -- Disobeys invariant: no double dot in filepath
"a.."
$(mkRelDir "a../") -- Disobeys invariant: no double dot in filepath
"a../"
```

Fixes are not part of this PR.
