### PR TITLE
Docs for `show` are misleading

### DIFF
--- a/src/Path/Internal.hs
+++ b/src/Path/Internal.hs
@@ -45,7 +45,7 @@ instance Eq (Path b t) where
 instance Ord (Path b t) where
   compare (Path x) (Path y) = compare x y
 
--- | Same as 'Path.toFilePath'.
+-- | Same as 'show . Path.toFilePath'.
 --
 -- The following property holds:
 --


### PR DESCRIPTION
Using `show` will include double quotes (as usual when `show`ing a `String`) but docs make it sound like the quotes are not included.